### PR TITLE
Fix Postgres port mapping in compose.yml

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -32,9 +32,9 @@ services:
       timeout: 5s
       retries: 5
     ports:
-      - "5432:5433"
+      - "5433:5432"
     expose:
-      - "5433"
+      - "5432"
     env_file:
       - database.env
     volumes:


### PR DESCRIPTION
- Changed port mapping from host:5432->container:5433 to host:5433->container:5432
- Solves connection issue to database from host os as Postgres is running in the container on port 5432 not 5433
- 5433 is the port exposed to host still to avoid conflicts