### PR TITLE
Produce on-demand HTML reports of the tests

### DIFF
--- a/server/masna3.cabal
+++ b/server/masna3.cabal
@@ -155,6 +155,7 @@ test-suite masna3-test
   -- cabal-gild: discover test --exclude "test/Main.hs"
   other-modules:
     Masna3.Test.File
+    Masna3.Test.StructuredOutput
     Masna3.Test.Utils
 
   build-depends:
@@ -167,10 +168,12 @@ test-suite masna3-test
     effectful-core,
     effectful-postgresql,
     envparse,
+    filepath,
     http-client,
     http-types,
     log-base,
     log-effectful,
+    lucid2,
     masna3,
     masna3:masna3-prelude,
     masna3-api,
@@ -184,6 +187,7 @@ test-suite masna3-test
     text,
     text-display,
     time,
+    vector,
     wai-log,
     warp,
 

--- a/server/test/Masna3/Test/File.hs
+++ b/server/test/Masna3/Test/File.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE OverloadedLists #-}
+
 module Masna3.Test.File where
 
 import Masna3.Api.Client qualified as Client
@@ -6,6 +8,7 @@ import Test.Tasty
 
 import Masna3.Server.Model.Owner.Types
 import Masna3.Server.Model.Owner.Update qualified as Update
+import Masna3.Test.StructuredOutput
 import Masna3.Test.Utils
 
 spec :: TestEnv -> TestTree
@@ -38,11 +41,16 @@ testConfirmFile = do
 
 testConfirmFileInvalidTransition :: TestEff ()
 testConfirmFileInvalidTransition = do
+  setHeader ["Operation", "Status"]
   owner <- newOwner "test-client-3"
   withTestPool $ Update.insertOwner owner
   let fileName = "toto.txt"
       mimeType = "text/plain"
   let form = FileRegistrationForm fileName owner.ownerId mimeType
   result <- assertRight "Register file" =<< runRequest (Client.registerFile form)
-  void $ assertRight "Confirm File" =<< runRequest (Client.confirmFile result.fileId)
-  void $ assertLeftWithStatus "Confirm File" 500 =<< runRequest (Client.confirmFile result.fileId)
+  do
+    void $ assertRight "Confirm File" =<< runRequest (Client.confirmFile result.fileId)
+    addRow ["Confirm file", "✅"]
+  do
+    assertLeftWithStatus "Confirm File" 500 =<< runRequest (Client.confirmFile result.fileId)
+    addRow ["Double-confirm file", "❌"]

--- a/server/test/Masna3/Test/StructuredOutput.hs
+++ b/server/test/Masna3/Test/StructuredOutput.hs
@@ -1,0 +1,56 @@
+module Masna3.Test.StructuredOutput where
+
+import Data.Aeson
+import Data.Text qualified as Text
+import Data.Vector qualified as Vector
+import Effectful
+import Effectful.FileSystem
+import Effectful.FileSystem.IO.ByteString.Lazy qualified as FileSystem
+import Effectful.State.Static.Shared (State)
+import Effectful.State.Static.Shared qualified as State
+import GHC.Generics
+import Lucid
+import System.FilePath
+
+data OutputTable = OutputTable
+  { tableName :: Text
+  , header :: Vector Text
+  , rows :: Vector (Vector Text)
+  }
+  deriving stock (Eq, Generic, Ord, Show)
+  deriving anyclass (FromJSON, ToJSON)
+
+writeTable :: FileSystem :> es => FilePath -> OutputTable -> Eff es ()
+writeTable destinationDirectory table = do
+  let html = renderBS $ toHTML table
+  let fileName = Text.unpack table.tableName
+  FileSystem.writeFile (destinationDirectory </> fileName <.> ".html") html
+
+setHeader :: State OutputTable :> es => Vector Text -> Eff es ()
+setHeader newHeader = State.modify $ \table ->
+  table{header = newHeader}
+
+addRow :: State OutputTable :> es => Vector Text -> Eff es ()
+addRow newRow = State.modify $ \table ->
+  table{rows = Vector.snoc table.rows newRow}
+
+toHTML :: OutputTable -> Html ()
+toHTML table = do
+  html_ [lang_ "en"] $ do
+    head_ $ do
+      meta_ [charset_ "UTF-8"]
+      meta_ [name_ "viewport", content_ "width=device-width, initial-scale=1"]
+    body_ [] $ do
+      table_ $ do
+        caption_ [style_ "white-space: nowrap; and overflow: hidden;"] (toHtml table.tableName)
+        thead_ $ do
+          tr_ $ do
+            forM_ table.header $ \header ->
+              th_ (toHtml header)
+        tbody_ $ do
+          forM_ table.rows $ \row -> do
+            tr_ $ do
+              let cells = Vector.tail row
+              th_ (toHtml $ Vector.head row)
+              forM_ cells $ \cell -> do
+                td_ (toHtml cell)

--- a/server/test/Masna3/Test/Utils.hs
+++ b/server/test/Masna3/Test/Utils.hs
@@ -22,12 +22,15 @@ import Effectful.Concurrent.MVar.Strict qualified as MVar
 import Effectful.Error.Static (Error)
 import Effectful.Error.Static qualified as Error
 import Effectful.Exception
+import Effectful.FileSystem
 import Effectful.Log (Log)
 import Effectful.Log qualified as Log
 import Effectful.PostgreSQL (WithConnection)
 import Effectful.PostgreSQL qualified as DB
 import Effectful.Reader.Static (Reader)
 import Effectful.Reader.Static qualified as Reader
+import Effectful.State.Static.Shared (State)
+import Effectful.State.Static.Shared qualified as State
 import Effectful.Time (Time)
 import Effectful.Time qualified as Time
 import Env qualified
@@ -36,18 +39,21 @@ import Log.Backend.LogList qualified as Log
 import Network.HTTP.Client (defaultManagerSettings, newManager)
 import Network.HTTP.Types (statusCode)
 import Servant.Client
+import System.FilePath ((</>))
 import Test.Tasty (TestTree)
 import Test.Tasty.HUnit qualified as Test
 
 import Masna3.Server.Config
 import Masna3.Server.Environment
 import Masna3.Server.Error
+import Masna3.Test.StructuredOutput
 
 type TestEff a =
   Eff
     '[ Time
      , Error Masna3Error
      , Reader TestEnv
+     , State OutputTable
      , Log
      , Concurrent
      , IOE
@@ -73,15 +79,21 @@ testThis env name assertion = Test.testCase (Text.unpack name) $ do
             Text.putStrLn $ "Logs from tests: " <> name <> ":"
             logs <- Log.getLogList logList
             forM_ logs (Text.putStrLn . Log.showLogMessage Nothing)
+        defaultTable = OutputTable name empty empty
     do
       -- bracket_ insertList deleteList $ do
       Log.withLogListLogger logList $ \logger -> do
-        assertion
-          & Time.runTime
-          & Error.runErrorWith handleTestSuiteError
-          & Reader.runReader env
-          & Log.runLog "masna3-test" logger Log.defaultLogLevel
-          & (`onException` displayLogsOnException)
+        finalState <-
+          assertion
+            & Time.runTime
+            & Error.runErrorWith handleTestSuiteError
+            & Reader.runReader env
+            & State.execState defaultTable
+            & Log.runLog "masna3-test" logger Log.defaultLogLevel
+            & (`onException` displayLogsOnException)
+        runFileSystem $ do
+          baseDir <- getCurrentDirectory
+          writeTable (baseDir </> ".." </> "dist-newstyle/tmp") finalState
   where
     handleTestSuiteError :: IOE :> es => CallStack -> Masna3Error -> Eff es a
     handleTestSuiteError callstack err = do


### PR DESCRIPTION
Test cases are enhanced with functions that allow us to report user-defined data under arbitrary formats. This PR introduces somewhat raw tables.

HTML files are located in `./dist-newstyle/tmp/`.

The HTML looks like:

```html
<caption style="white-space: nowrap; and overflow: hidden;">Confirm File Invalid Transition</caption>
<thead>
  <tr>
    <th>Operation</th>
    <th>Status</th>
  </tr>
</thead>
<tbody>
  <tr>
    <th>Confirm file</th>
    <td>✅</td>
  </tr>
  <tr>
    <th>Double-confirm file</th>
    <td>❌</td>
  </tr>
</tbody>
```