### PR TITLE
Reintroduce Arabic name in README.md with BiDi formatting for correct display

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# 🏭 Masnaع [![Made with Haskell](https://img.shields.io/badge/Made%20in-Haskell-%235e5086?logo=haskell&style=flat-square)](https://haskell.org)
+# 🏭 Masnaع (⁨مصنع⁩) [![Made with Haskell](https://img.shields.io/badge/Made%20in-Haskell-%235e5086?logo=haskell&style=flat-square)](https://haskell.org)
 
-Masnaع is a file store service. It acts as a synchronisation backend service between user-facing clients (Frontend application, mobile app, product backend), and object storage services – like Amazon S3.
+Masnaع (⁨مصنع⁩) is a file store service. It acts as a synchronisation backend service between user-facing clients (Frontend application, mobile app, product backend), and object storage services – like Amazon S3.
 To account for the diversity of file upload workflows, Masna3 does not perform the upload and downloads itself, but creates pre-signed URLs that allow clients to upload and download
 files. These URLs refer to particular object, serve one specific purpose (upload or download), and have an expiration time.
 


### PR DESCRIPTION
Previously, in the string “Masnaع (مصنع)”, the sequence “ع (مصنع)”, since it consists only of Arabic letters, which are right-to-left, along with space and parens, which don’t have fixed directionality, indicated a single run of right-to-left text within the wider left-to-right document, which led to it being displayed differently than intended.

To fix this, in the string “Masnaع (⁨مصنع⁩)”, the word ⁨مصنع⁩ is surrounded by a `First Strong Isolate` … `Pop Directional Isolate` pair to directionally isolate it from its surroundings, preventing it from forming an RTL run with the separate ع⁩ and the surrounding parens and space. This means that the individual ع and the word ⁨مصنع⁩ are each considered a separate right-to-left run within the left-to-right text, and the space and parens are considered part of the left-to-right surroundings instead, which, as far as I understand, is the intended semantics of this sequence and results in the desired display.

Arguably, the individual ع should be “overridden” with a `Left-to-Right Override` … `Pop Directional Formatting` pair to be considered a left-to-right character as part of a left-to-right word, but the directional override formatting codepoints have been used for significant mischief and are thus often stripped by applications, and for the single character, this is not necessary to get the right appearance.